### PR TITLE
MakerDAO Proposal API Added

### DIFF
--- a/pages/api/proposal.js
+++ b/pages/api/proposal.js
@@ -263,21 +263,19 @@ async function getCompoundProposals(blockNumber) {
 async function getMakerProposals(blockNumber) {
     var makerProposals = [];
     // executive proposals 
-    var query = `{
-        about 
-        content
-        title
-        proposalBlurb
-        key
-        address
-        date
-        active
-        proposalLink
-        spellData
-    }`;
-    const exec_response = await axios.post('https://vote.makerdao.com/api/executive?start=0&limit=10', {
-        query: query 
-    },
+    // var query = `{
+    //     about 
+    //     content
+    //     title
+    //     proposalBlurb
+    //     key
+    //     address
+    //     date
+    //     active
+    //     proposalLink
+    //     spellData
+    // }`;
+    const exec_response = await axios.get('https://vote.makerdao.com/api/executive?start=0&limit=3&active=active', 
     {
         headers: {
             'Content-Type': 'application/json'
@@ -290,44 +288,43 @@ async function getMakerProposals(blockNumber) {
 
         var title = proposal.title;
         var id = proposal.address;
-        var platform = "Maker";
-        var state = proposal.active;
+        var platform = "Maker Executive";
+        var state = "active";
         var link = proposal.proposalLink;
+        var endBlock = parseInt(proposal.blockCreated); //TODO
         var proposalJSON = {
             title: title,
             id: id,
             platform: platform,
-            state: state.toLowerCase(),
+            state: state,
             link: link,
-            endBlock: endBlock
+            endBlock: null
         }
         makerProposals.push(proposalJSON);
     }
 
     // polls 
-    var query = `{
-        polls(orderBy: blockCreated, orderDirection: desc) { 
-            creator 
-            pollId
-            blockCreated
-            startDate
-            endDate 
-            multiHash 
-            url
-            cursor
-            slug
-            parameters 
-            content 
-            summary
-            title
-            options
-            discussionLink
-            tags 
-        }
-    }`;
-    const poll_response = await axios.post('https://vote.makerdao.com/api/polling/all-polls', {
-        query: query 
-    },
+    // var query = `{
+    //     polls(orderBy: blockCreated, orderDirection: desc) { 
+    //         creator 
+    //         pollId
+    //         blockCreated
+    //         startDate
+    //         endDate 
+    //         multiHash 
+    //         url
+    //         cursor
+    //         slug
+    //         parameters 
+    //         content 
+    //         summary
+    //         title
+    //         options
+    //         discussionLink
+    //         tags 
+    //     }
+    // }`;
+    const poll_response = await axios.get('https://vote.makerdao.com/api/polling/all-polls', 
     {
         headers: {
             'Content-Type': 'application/json'
@@ -340,18 +337,24 @@ async function getMakerProposals(blockNumber) {
 
         var title = proposal.title;
         var id = proposal.pollId;
-        var platform = "Maker";
+        var platform = "Maker Poll";
         var endDate = new Date(proposal.endDate);
         var currDate = new Date(); 
-        var state = (endDate > currDate) ? "active" : "past";
+        var state = (endDate < currDate) ? "active" : "past";
+        // clear out proposals that were started more than 2 weeks ago
+        var startDate = new Date(proposal.startDate); 
+        startDate.setDate(startDate.getDate() + 14); 
+
+        if (state != "active" || startDate < currDate) break; 
         var link = proposal.url;
+        var endBlock = parseInt(proposal.blockCreated); //TODO
         var proposalJSON = {
             title: title,
             id: id,
             platform: platform,
-            state: state.toLowerCase(),
+            state: state,
             link: link,
-            endBlock: endBlock
+            endBlock: null
         }
         makerProposals.push(proposalJSON);
     }


### PR DESCRIPTION
MakerDAO Governance API endpoints added to include: 
- the last 3 active executive proposals; 
- current active poll proposals that started less than 2 weeks ago. 

The parameter for verbosity and amount to display are up to change on current line 278 query limit and line 346 proposal time span. 